### PR TITLE
add XAR related files

### DIFF
--- a/shellcromancer/file_dmg.yar
+++ b/shellcromancer/file_dmg.yar
@@ -19,3 +19,18 @@ rule file_dmg
 			uint32be(@ + 4) == 4
 		)
 }
+
+rule file_dmg_condition_only
+{
+	meta:
+		description = "Identify Apple DMG files."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.10"
+		sample = "9ceea14642a1fa4bc5df189311a9e01303e397531a76554b4d975301c0b0e5c8"
+		reference = "http://newosxbook.com/DMG.html"
+		DaysofYARA = "10/100"
+
+	condition:
+		uint32be(filesize - 512) == 0x6b6f6c79
+}

--- a/shellcromancer/file_xar.yar
+++ b/shellcromancer/file_xar.yar
@@ -1,0 +1,13 @@
+rule head_xar
+{
+	meta:
+		description = "Identify Apple eXtensible ARchive files (.xar, .pkg, .safariextz, .xip, etc)."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.09"
+		reference = "https://github.com/apple-oss-distributions/xar"
+		DaysofYARA = "9/100"
+
+	condition:
+		uint32be(0) == 0x78617221
+}

--- a/shellcromancer/xar.hexpat
+++ b/shellcromancer/xar.hexpat
@@ -1,0 +1,39 @@
+#pragma MIME application/x-xar
+#pragma endian big
+
+//  References:
+// https://en.wikipedia.org/wiki/Xar_(archiver)
+// https://github.com/mackyle/xar/wiki/xarformat
+
+#include <std/mem.pat>
+#include <type/magic.pat>
+#include <type/size.pat>
+
+// https://github.com/apple-oss-distributions/xar/blob/f67a3a8c43fdd35021fd3d1562b62d2da32b4f4b/xar/include/xar.h.in#L73
+enum ChecksumAlg : u32 {
+    None    = 0x00,
+    SHA1    = 0x01,
+    MD5     = 0x02,
+    SHA_256 = 0x03,
+    SHA_512 = 0x04,
+};
+
+// XarHeader
+// https://github.com/apple-oss-distributions/xar/blob/f67a3a8c43fdd35021fd3d1562b62d2da32b4f4b/xar/include/xar.h.in#L59
+struct XarHeader {
+    type::Magic<"xar!"> magic;              // Magic ('xar!')
+    type::Size<u16> size;                   // Header Size
+    u16 version;                            // Current version is 1
+    type::Size<u64> toc_length_compressed;
+    type::Size<u64> toc_length_uncompressed;
+    ChecksumAlg cksum_alg;
+};
+
+struct Xar {
+    XarHeader hdr;
+    char toc[hdr.toc_length_compressed];    // zlib XML Plist
+    char heap[std::mem::size() - $];        // data to be decoded from toc
+};
+
+
+Xar xar @ 0x00;


### PR DESCRIPTION
Day 09: Adds a YARA rule to detect Darwins XAR files, and a ImHex pattern for viewing the header information.
Day 10: Adds a new YARA rule for DMG files without the strings component.