### PR TITLE
Add extra brackets to rule

### DIFF
--- a/bitsofbinary/LNK_Zeroed_Header_Timestamps.yar
+++ b/bitsofbinary/LNK_Zeroed_Header_Timestamps.yar
@@ -3,7 +3,7 @@ rule Heuristic_LNK_Zeroed_Header_Timestamp {
         author = "BitsOfBinary"
         description = "Detects an LNK file with a creation/write/access timestamp that has been zeroed out"
         reference = "https://bitsofbinary.github.io/yara/2023/01/09/100daysofyara-day-9.html"
-        version = "1.0"
+        version = "1.1"
         date = "2023-01-09"
         DaysofYARA = "9/100"
         
@@ -13,16 +13,18 @@ rule Heuristic_LNK_Zeroed_Header_Timestamp {
         uint32(8) == 0x00000000 and
         uint32(12) == 0x000000C0 and
         uint32(16) == 0x46000000 and
-        // Creation timestamp
         (
-            uint32(28) == 0 and uint32(32) == 0
-        ) or
-        // Access timestamp
-        (
-            uint32(36) == 0 and uint32(40) == 0
-        ) or
-        // Write timestamp
-        (
-            uint32(44) == 0 and uint32(48) == 0
+            // Creation timestamp
+            (
+                uint32(28) == 0 and uint32(32) == 0
+            ) or
+            // Access timestamp
+            (
+                uint32(36) == 0 and uint32(40) == 0
+            ) or
+            // Write timestamp
+            (
+                uint32(44) == 0 and uint32(48) == 0
+            )
         )
 }


### PR DESCRIPTION
Messed up this rule because I didn't add the right brackets in which meant the or statements didn't evaluate how I wanted... Should've checked this one more carefully