### PR TITLE
add file_plist.yar

### DIFF
--- a/shellcromancer/file_plist.yar
+++ b/shellcromancer/file_plist.yar
@@ -1,0 +1,39 @@
+rule file_plist
+{
+	meta:
+		description = "Identify Apple Property List Files (binary, XML or otherwise)."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.12"
+		reference = "http://newosxbook.com/bonus/bplist.pdf"
+		reference = "https://medium.com/@karaiskc/understanding-apples-binary-property-list-format-281e6da00dbd"
+		DaysofYARA = "12/100"
+
+	strings:
+		$bplist = { 62 70 6C 69 73 74 3? 3? }
+		$dtd = "http://www.apple.com/DTDs/PropertyList-1.0.dtd"
+
+	condition:
+		$bplist at 0 or
+		$dtd
+}
+
+rule plist_persistence
+{
+	meta:
+		description = "Identify common Property List keys in malware."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.12"
+		reference = "https://www.launchd.info"
+		DaysofYARA = "12/100"
+
+	strings:
+		$s1 = "RunAtLoad"
+		$s2 = "KeepAlive"
+		$s3 = "UserName"
+
+	condition:
+		file_plist and
+		any of them
+}

--- a/shellcromancer/file_scpt.yar
+++ b/shellcromancer/file_scpt.yar
@@ -1,0 +1,20 @@
+rule file_applescript
+{
+	meta:
+		description = "Identify Compiled AppleScript Programs"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.13"
+		reference = "https://applescriptlibrary.wordpress.com"
+		reference = "https://www.sentinelone.com/labs/fade-dead-adventures-in-reversing-malicious-run-only-applescripts/"
+		sample = "b954af3ee83e5dd5b8c45268798f1f9f4b82ecb06f0b95bf8fb985f225c2b6af"
+		DaysofYARA = "13/100"
+
+	strings:
+		$head = { 46 61 73 64 55 41 53 20 }
+		$tail = { fa de de ad }
+
+	condition:
+		$head at 0 and
+		$tail at filesize - 4
+}


### PR DESCRIPTION
Day 12: Adds identification of plist files (XML, binary, or generally embedded) and then uses that to look for common malware keys.
Day 13: Adds identification of compiled AppleScript executables.