### PR TITLE
Adds macho_discovery.yar, lang_swift.yar, and file_scpt_jxa.yar

### DIFF
--- a/shellcromancer/file_scpt_jxa.yar
+++ b/shellcromancer/file_scpt_jxa.yar
@@ -1,0 +1,21 @@
+rule file_jxa_script
+{
+	meta:
+		description = "Identify JavaScript for Automation Programs"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.16"
+		reference = "https://tylergaw.com/blog/building-osx-apps-with-js/"
+		reference = "https://posts.specterops.io/persistent-jxa-66e1c3cd1cf5"
+		DaysofYARA = "16/100"
+
+	strings:
+		$head = { 4A 73 4F 73 61 44 41 53 }
+		$type = { 6A 73 63 72 }
+		$tail = { fa de de ad }
+
+	condition:
+		$head at 0 and
+		$type and
+		$tail at filesize - 4
+}

--- a/shellcromancer/lang_swift.yar
+++ b/shellcromancer/lang_swift.yar
@@ -1,0 +1,23 @@
+rule lang_swift
+{
+	meta:
+		description = "Identify a Swift binary regardless of targetting Apple platforms."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.14"
+		DaysofYARA = "14/100"
+
+	strings:
+		$swift = "__swift"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		#swift >= 4
+}

--- a/shellcromancer/macho_discovery.yar
+++ b/shellcromancer/macho_discovery.yar
@@ -1,0 +1,46 @@
+private rule file_macho
+{
+	meta:
+		description = "Identify a mach-o binary abusing injection mechanisms."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.15"
+		DaysofYARA = "15/100"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		)
+}
+
+rule macho_discovery_imports
+{
+	meta:
+		description = "Identify a mach-o binary abusing injection mechanisms."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.15"
+		DaysofYARA = "15/100"
+		reference = "https://github.com/cedowens/SwiftBelt/blob/master/Sources/SwiftBelt/main.swift"
+
+	strings:
+		$s1 = "NSProcessInfo" ascii fullword // Environment Variable listing
+		$s2 = "NSUserName" ascii fullword
+		$s3 = "NSHomeDirectory" ascii fullword
+		$s4 = "NSUserDefaults" ascii fullword
+		$s5 = "NSWorkspace" ascii fullword                    // Process listing
+		$s6 = "sysctlbyname" ascii fullword                   // Kernel & Hostname listing
+		$s7 = "CGSessionCopyCurrentDictionary" ascii fullword // Screen Lock Status
+		$s8 = "NSPasteboard" ascii fullword                   // Clipboard listing
+		$s9 = "AXIsProcessTrusted" ascii fullword             // TCC Trust Level listing
+
+	condition:
+		file_macho and
+		40% of them
+}
+


### PR DESCRIPTION
Adds 3 days of rules:
- lang_swift.yar: identification of Swift binaries
- macho_discovery: identification of discovery tactics in machos
- file_scpt_jxa: identification of JavaScript for automation files