### PR TITLE
add mal_cia_ransomware & file_car

### DIFF
--- a/shellcromancer/file_car.yar
+++ b/shellcromancer/file_car.yar
@@ -1,0 +1,25 @@
+rule file_car
+{
+	meta:
+		description = "Identify Apple Compiled Asset Record files (.car). Inspect contents with `assetutil -I`"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.30"
+		reference = "https://blog.timac.org/2018/1018-reverse-engineering-the-car-file-format/"
+		DaysofYARA = "30/100"
+
+	strings:
+		$bomstore = { 42 4F 4D 53 74 6F 72 65 }
+
+		$block1 = "CARHEADER"
+		$block2 = "EXTENDED_METADATA"
+		$block3 = "KEYFORMAT"
+
+		$tree1 = "FACETKEYS"
+		$tree2 = "RENDITIONS"
+
+	condition:
+		$bomstore at 0 and
+		all of them
+}
+

--- a/shellcromancer/mal_cia_ransomware.yar
+++ b/shellcromancer/mal_cia_ransomware.yar
@@ -1,0 +1,21 @@
+rule mal_cia_ransomware
+{
+	meta:
+		description = "Identify macOS CIA ransomware"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.29"
+		sample = "1de673936636733112f29c8b8e15867ef1f288c5e5799615348f7a569c523de4"
+		DaysofYARA = "29/100"
+
+	strings:
+		$log = "tagging file: %s"
+		$name = "http://%s:8080/readme"
+		$cia = "cia.gov was here"
+		$background = "github.com/reujab/wallpaper.SetFromURL"
+		$destop = "/Desktop2"
+		$image = "http://%s:8080/imageinconsistent"
+
+	condition:
+		all of them
+}


### PR DESCRIPTION
Adds 2 new rules:
- string based detection for the CIA ransomware shared on MalwareBazar for macOS in December 2022
- detection of the Apple CAR file format where the `file` command misleads you.