### PR TITLE
Update rules

### DIFF
--- a/shellcromancer/electron.yar
+++ b/shellcromancer/electron.yar
@@ -1,0 +1,49 @@
+rule macho_electron
+{
+	meta:
+		description = "Identify Electron based executables. Stub Macho that loads JS."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.02.03"
+		reference = "https://github.com/electron/electron"
+		DaysofYARA = "34/100"
+
+	strings:
+		$s1 = "ELECTRON_RUN_AS_NODE"
+		$s2 = "Electron Framework.framework"
+		$s3 = "_ElectronMain"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		all of them
+}
+
+rule file_asar
+{
+	meta:
+		description = "Identify Electron archives bundles (.asar)"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.02.03"
+		reference = "https://github.com/electron/asar"
+		DaysofYARA = "34/100"
+
+	strings:
+		$header = { 04 00 00 00 }
+
+		$key1 = "files"
+		$key2 = "integrity"
+		$key3 = "offset"
+
+	condition:
+		$header at 0 and
+		all of them
+}
+

--- a/shellcromancer/hacktool_ezuri.yar
+++ b/shellcromancer/hacktool_ezuri.yar
@@ -1,0 +1,25 @@
+rule hacktool_ezuri
+{
+	meta:
+		description = "Identify an ELF executable written packed with the Ezuri crypter."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.02.02"
+		reference = "https://www.guitmz.com/linux-elf-runtime-crypter/"
+		reference = "https://github.com/guitmz/ezuri"
+		sample = "ddbb714157f2ef91c1ec350cdf1d1f545290967f61491404c81b4e6e52f5c41f"
+		DaysofYARA = "33/100"
+
+	strings:
+		$memfd_self = "/proc/self/fd/%d"
+		$output = "/dev/null"
+
+		$sym1 = "runFromMemory" // stub/main.go
+		$sym2 = "aesDec"        // stub/main.go
+		$sym3 = "procName"      // stub/vars.go
+
+	condition:
+		uint32(0) == 0x464c457f and // and // ELF
+		all of them
+}
+

--- a/shellcromancer/hacktool_shc.yar
+++ b/shellcromancer/hacktool_shc.yar
@@ -4,20 +4,32 @@ rule hacktool_shc
 	meta:
 		description = "Identify ELF executables built with the shc compiler"
 		author = "@shellcromancer"
-		version = "1.0"
-		last_modified = "2023.01.22"
+		version = "1.1"
+		last_modified = "2023.02.01"
 		reference = "https://neurobin.org/projects/softwares/unix/shc/"
 		reference = "https://asec.ahnlab.com/en/45182/"
 		sample = "d2626acc7753a067014f9d5726f0e44ceba1063a1cd193e7004351c90875f071"
 		DaysofYARA = "22/100"
+		DaysofYARA = "32/100"
 
 	strings:
 		$s1 = "neither argv[0] nor"
 		$s2 = "%s%s%s: %s"
 
+		$default_expiry = "jahidulhamid@yahoo.com"
+
 	condition:
-		uint32(0) == 0x464c457f and // ELF
-		all of them
+		(
+			int16(0) == 0x5a4d or      // PE
+			uint32(0) == 0x464c457f or // ELF
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		2 of them
 }
 
 
@@ -25,14 +37,15 @@ rule hacktool_shc
 rule hacktool_shc_rm_arg
 {
 	meta:
-		description = "Identify ELF executables built with the shc compiler using the rmargs function"
+		description = "Identify executables built with the shc compiler using the rmargs function"
 		author = "@shellcromancer"
-		version = "1.0"
-		last_modified = "2023.01.23"
+		version = "1.1"
+		last_modified = "2023.02.01"
 		reference = "https://neurobin.org/projects/softwares/unix/shc/"
 		reference = "https://asec.ahnlab.com/en/45182/"
 		sample = "d2626acc7753a067014f9d5726f0e44ceba1063a1cd193e7004351c90875f071"
 		DaysofYARA = "23/100"
+		DaysofYARA = "32/100"
 
 	strings:
 		$rmargs = {
@@ -60,7 +73,58 @@ rule hacktool_shc_rm_arg
 			48 85 C0       // test rax, rax
 		}
 
+		$clang_0x10000357e = {
+			48 83 7d f8 00 //   cmp     qword [rbp-0x8 {var_10}], 0x0
+			88 45 ef       //   mov     byte [rbp-0x11 {var_19_1}], al  {0x0}
+			0f 84 [4]      //   je      0x1000035b0
+			48 8b 4d f8    //   mov     rcx, qword [rbp-0x8 {var_10}]
+			31 c0          //   xor     eax, eax  {0x0}
+			48 83 39 00    //   cmp     qword [rcx], 0x0
+			88 45 ef       //   mov     byte [rbp-0x11 {var_19_1}], al  {0x0}
+			0f 84 [4]      //   je      0x1000035b0
+			48 8b 45 f8    //   mov     rax, qword [rbp-0x8 {var_10}]
+			48 8b 00       //   mov     rax, qword [rax]
+			48 3b 45 f0    //   cmp     rax, qword [rbp-0x10 {var_18}]
+			0f 95 c0       //   setne   al
+			88 45 ef       //   mov     byte [rbp-0x11 {var_19_1}], al
+			8a 45 ef       //   mov     al, byte [rbp-0x11 {var_19_1}]
+			a8 01          //   test    al, 0x1
+			0f 85 [4]      //   jne     0x1000035c0
+			e9 [4]         //   jmp     0x1000035d6
+			e9 [4]         //   jmp     0x1000035c5
+			48 8b 45 f8    //   mov     rax, qword [rbp-0x8 {var_10}]
+			48 83 c0 08    //   add     rax, 0x8
+			48 89 45 f8    //   mov     qword [rbp-0x8 {var_10}], rax
+			e9 [4]         //   jmp     0x10000357c
+			e9 [4]         //   jmp     0x1000035db
+			31 c0          //   xor     eax, eax  {0x0}
+			48 83 7d f8 00 //   cmp     qword [rbp-0x8 {var_10}], 0x0
+			88 45 ee       //   mov     byte [rbp-0x12 {var_1a_1}], al  {0x0}
+			0f 84 [4]      //   je      0x1000035f9
+			48 8b 45 f8    //   mov     rax, qword [rbp-0x8 {var_10}]
+			48 83 38 00    //   cmp     qword [rax], 0x0
+			0f 95 c0       //   setne   al
+			88 45 ee       //   mov     byte [rbp-0x12 {var_1a_1}], al
+			8a 45 ee       //   mov     al, byte [rbp-0x12 {var_1a_1}]
+			a8 01          //   test    al, 0x1
+			0f 85 [4]      //   jne     0x100003609
+			e9 [4]         //   jmp     0x100003629
+			48 8b 45 f8    //   mov     rax, qword [rbp-0x8 {var_10}]
+			48 8b 48 08    //   mov     rcx, qword [rax+0x8]
+			48 8b 45 f8    //   mov     rax, qword [rbp-0x8 {var_10}]
+		}
 	condition:
-		uint32(0) == 0x464c457f and // ELF
-		all of them
+		(
+			int16(0) == 0x5a4d or      // PE
+			uint32(0) == 0x464c457f or // ELF
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		any of them
 }
+
+

--- a/shellcromancer/info_macho_lc_cmds.yar
+++ b/shellcromancer/info_macho_lc_cmds.yar
@@ -1,0 +1,60 @@
+import "macho"
+
+rule info_macho_lc_cmd_encryption_info
+{
+	meta:
+		description = "Identify Mach-O executables that are encrypted (have LC_ENCRYPTION_INFO or LC_ENCRYPTION_INFO_64)."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.31"
+		DaysofYARA = "31/100"
+
+	condition:
+		(
+			uint32be(0) == 0xCFFAEDFE or
+			uint32be(0) == 0xCEFAEDFE
+		) and
+		for any cmd in (0 .. macho.sizeofcmds) : (
+			uint32be(cmd) == 0x21000000 or
+			uint32be(cmd) == 0x2C000000
+		)
+}
+
+rule info_macho_lc_cmd_min_version
+{
+	meta:
+		description = "Identify Mach-O executables that specify a minimum version (LC_VERSION_MIN_MACOSX or LC_VERSION_MIN_IPHONEOS)."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.31"
+		DaysofYARA = "31/100"
+
+	condition:
+		(
+			uint32be(0x0) == 0xCFFAEDFE or
+			uint32be(0x0) == 0xCEFAEDFE
+		) and
+		for any cmd in (0 .. macho.sizeofcmds) : (
+			uint32be(cmd) == 0x24000000 or
+			uint32be(cmd) == 0x25000000
+		)
+}
+
+rule info_macho_lc_cmd_code_signature
+{
+	meta:
+		description = "Identify Mach-O executables that are signed (has LC_CODE_SIGNATURE)."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.01.31"
+		DaysofYARA = "31/100"
+
+	condition:
+		(
+			uint32be(0) == 0xCFFAEDFE or
+			uint32be(0) == 0xCEFAEDFE
+		) and
+		for any cmd in (0 .. macho.sizeofcmds) : (
+			uint32be(cmd) == 0x1D000000
+		)
+}


### PR DESCRIPTION
Adds a few rules for the last few days:

- SHC compiler for macOS
- Specific Macho LC Commands 
- Ezuri crypter detection
- Electron application identification