### PR TITLE
Poor Performance XOR

### DIFF
--- a/malvidin/100_days_of_yara.yara
+++ b/malvidin/100_days_of_yara.yara
@@ -6,7 +6,12 @@ rule days_of_yara_url_2byte
     description = "Look for two byte xor of target string. Creating ~64K separate rules is faster (~12MB rule file)"
     warning = "Loops over entire file, very poor performance."
     target_string = "https://github.com/100DaysofYARA"
+
+  strings:
+    $target_string = /https:\/\/github\.com\/100DaysofYARA/
+
   condition:
+    not $target_string and
     for any i in ( 0 .. filesize ) : (
         uint16be(i) ^ uint16be(i+2) == 0x1c04
         and not for 0x2dfc0 j in ( i+0, i+2, i+4, i+6, i+8, i+10, i+12, i+14, i+16, i+18, i+20, i+22, i+24, i+26, i+28 ) : ( 
@@ -23,7 +28,12 @@ rule days_of_yara_url_3byte
     description = "Look for three byte xor of target string. Creating ~16M separate rules would probably be faster (~3.2 GB rule file)"
     warning = "Loops over entire file, very poor performance."
     target_string = "https://github.com/100DaysofYARA"
+
+  strings:
+    $target_string = /https:\/\/github\.com\/100DaysofYARA/
+
   condition:
+    not $target_string and
     for any i in ( 0 .. filesize ) : ( 
       ( ( uint32be(i) ^ uint32be(i+3) ) >> 8 ) == 0x18074e
       and not for 0x1c4172e j in ( i+0, i+3, i+6, i+9, i+12, i+15, i+18, i+21, i+24 ) : ( 
@@ -42,7 +52,12 @@ rule days_of_yara_url_4byte
     description = "Look for four byte xor of target string. Creating ~4G separate rules would probably be faster (~860 GB rule file)"
     warning = "Loops over entire file, very poor performance."
     target_string = "https://github.com/100DaysofYARA"
+
+  strings:
+    $target_string = /https:\/\/github\.com\/100DaysofYARA/
+
   condition:
+    not $target_string and
     for any i in ( 0 .. filesize ) : ( 
       uint32be(i) ^ uint32be(i+4) == 0x1b4e5b5f
       and not for 0x1248ee582 j in ( i+0, i+4, i+8, i+12, i+16, i+20, i+24 ) : ( 

--- a/malvidin/100_days_of_yara.yara
+++ b/malvidin/100_days_of_yara.yara
@@ -1,0 +1,55 @@
+
+rule days_of_yara_url_2byte
+{
+  meta:
+    author = "malvidin"
+    description = "Look for two byte xor of target string. Creating ~64K separate rules is faster (~12MB rule file)"
+    warning = "Loops over entire file, very poor performance."
+    target_string = "https://github.com/100DaysofYARA"
+  condition:
+    for any i in ( 0 .. filesize ) : (
+        uint16be(i) ^ uint16be(i+2) == 0x1c04
+        and not for 0x2dfc0 j in ( i+0, i+2, i+4, i+6, i+8, i+10, i+12, i+14, i+16, i+18, i+20, i+22, i+24, i+26, i+28 ) : ( 
+            uint16be(j) ^ uint16be(j+2) 
+        )
+        and for 0x2dfbf j in ( i+0, i+2, i+4, i+6, i+8, i+10, i+12, i+14, i+16, i+18, i+20, i+22, i+24, i+26, i+28 ) : ( uint16be(j) ^ uint16be(j+2) )
+    )
+}
+
+rule days_of_yara_url_3byte 
+{
+  meta:
+    author = "malvidin"
+    description = "Look for three byte xor of target string. Creating ~16M separate rules would probably be faster (~3.2 GB rule file)"
+    warning = "Loops over entire file, very poor performance."
+    target_string = "https://github.com/100DaysofYARA"
+  condition:
+    for any i in ( 0 .. filesize ) : ( 
+      ( ( uint32be(i) ^ uint32be(i+3) ) >> 8 ) == 0x18074e
+      and not for 0x1c4172e j in ( i+0, i+3, i+6, i+9, i+12, i+15, i+18, i+21, i+24 ) : ( 
+        ( uint32be(j) ^ uint32be(j+3) ) >> 8 
+      )
+      and for 0x1c4172d j in ( i+0, i+3, i+6, i+9, i+12, i+15, i+18, i+21, i+24 ) : ( 
+        ( uint32be(j) ^ uint32be(j+3) ) >> 8
+      )
+    )
+}
+
+rule days_of_yara_url_4byte 
+{
+  meta:
+    author = "malvidin"
+    description = "Look for four byte xor of target string. Creating ~4G separate rules would probably be faster (~860 GB rule file)"
+    warning = "Loops over entire file, very poor performance."
+    target_string = "https://github.com/100DaysofYARA"
+  condition:
+    for any i in ( 0 .. filesize ) : ( 
+      uint32be(i) ^ uint32be(i+4) == 0x1b4e5b5f
+      and not for 0x1248ee582 j in ( i+0, i+4, i+8, i+12, i+16, i+20, i+24 ) : ( 
+        uint32be(j) ^ uint32be(j+4) 
+      )
+      and for 0x1248ee581 j in ( i+0, i+4, i+8, i+12, i+16, i+20, i+24 ) : ( 
+        uint32be(j) ^ uint32be(j+4)
+      )
+    )
+}

--- a/malvidin/current_version.yara
+++ b/malvidin/current_version.yara
@@ -6,7 +6,12 @@ rule current_version_2byte
     description = "Look for two byte xor of target string. Creating ~64K separate rules is faster (~12MB rule file)"
     warning = "Loops over entire file, very poor performance."
     target_string = "Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+
+  strings:
+    $target_string = /Software\\Microsoft\\Windows\\CurrentVersion\\Run/
+
   condition:
+    not $target_string and
     for any i in ( 0 .. filesize ) : (
         uint16be(i) ^ uint16be(i+2) == 0x351b
         and not for 0x2a153 j in ( i+0, i+2, i+4, i+6, i+8, i+10, i+12, i+14, i+16, i+18, i+20, i+22, i+24, i+26, i+28, i+30, i+32, i+34, i+36, i+38, i+40 ) : ( 
@@ -23,7 +28,12 @@ rule current_version_3byte
     description = "Look for three byte xor of target string. Creating ~16M separate rules would probably be faster (~3.2 GB rule file)"
     warning = "Loops over entire file, very poor performance."
     target_string = "Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+
+  strings:
+    $target_string = /Software\\Microsoft\\Windows\\CurrentVersion\\Run/
+
   condition:
+    not $target_string and
     for any i in ( 0 .. filesize ) : ( 
       ( ( uint32be(i) ^ uint32be(i+3) ) >> 8 ) == 0x271807
       and not for 0x21267b9 j in ( i+0, i+3, i+6, i+9, i+12, i+15, i+18, i+21, i+24, i+27, i+30, i+33, i+36, i+39 ) : ( 
@@ -42,7 +52,12 @@ rule current_version_4byte
     description = "Look for four byte xor of target string. Creating ~4G separate rules would probably be faster (~860 GB rule file)"
     warning = "Loops over entire file, very poor performance."
     target_string = "Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+
+  strings:
+    $target_string = /Software\\Microsoft\\Windows\\CurrentVersion\\Run/
+
   condition:
+    not $target_string and
     for any i in ( 0 .. filesize ) : ( 
       uint32be(i) ^ uint32be(i+4) == 0x240e1411
       and not for 0x113ecb50a j in ( i+0, i+4, i+8, i+12, i+16, i+20, i+24, i+28, i+32, i+36 ) : ( 

--- a/malvidin/current_version.yara
+++ b/malvidin/current_version.yara
@@ -1,0 +1,55 @@
+
+rule current_version_2byte
+{
+  meta:
+    author = "malvidin"
+    description = "Look for two byte xor of target string. Creating ~64K separate rules is faster (~12MB rule file)"
+    warning = "Loops over entire file, very poor performance."
+    target_string = "Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+  condition:
+    for any i in ( 0 .. filesize ) : (
+        uint16be(i) ^ uint16be(i+2) == 0x351b
+        and not for 0x2a153 j in ( i+0, i+2, i+4, i+6, i+8, i+10, i+12, i+14, i+16, i+18, i+20, i+22, i+24, i+26, i+28, i+30, i+32, i+34, i+36, i+38, i+40 ) : ( 
+            uint16be(j) ^ uint16be(j+2) 
+        )
+        and for 0x2a152 j in ( i+0, i+2, i+4, i+6, i+8, i+10, i+12, i+14, i+16, i+18, i+20, i+22, i+24, i+26, i+28, i+30, i+32, i+34, i+36, i+38, i+40 ) : ( uint16be(j) ^ uint16be(j+2) )
+    )
+}
+
+rule current_version_3byte 
+{
+  meta:
+    author = "malvidin"
+    description = "Look for three byte xor of target string. Creating ~16M separate rules would probably be faster (~3.2 GB rule file)"
+    warning = "Loops over entire file, very poor performance."
+    target_string = "Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+  condition:
+    for any i in ( 0 .. filesize ) : ( 
+      ( ( uint32be(i) ^ uint32be(i+3) ) >> 8 ) == 0x271807
+      and not for 0x21267b9 j in ( i+0, i+3, i+6, i+9, i+12, i+15, i+18, i+21, i+24, i+27, i+30, i+33, i+36, i+39 ) : ( 
+        ( uint32be(j) ^ uint32be(j+3) ) >> 8 
+      )
+      and for 0x21267b8 j in ( i+0, i+3, i+6, i+9, i+12, i+15, i+18, i+21, i+24, i+27, i+30, i+33, i+36, i+39 ) : ( 
+        ( uint32be(j) ^ uint32be(j+3) ) >> 8
+      )
+    )
+}
+
+rule current_version_4byte 
+{
+  meta:
+    author = "malvidin"
+    description = "Look for four byte xor of target string. Creating ~4G separate rules would probably be faster (~860 GB rule file)"
+    warning = "Loops over entire file, very poor performance."
+    target_string = "Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+  condition:
+    for any i in ( 0 .. filesize ) : ( 
+      uint32be(i) ^ uint32be(i+4) == 0x240e1411
+      and not for 0x113ecb50a j in ( i+0, i+4, i+8, i+12, i+16, i+20, i+24, i+28, i+32, i+36 ) : ( 
+        uint32be(j) ^ uint32be(j+4) 
+      )
+      and for 0x113ecb509 j in ( i+0, i+4, i+8, i+12, i+16, i+20, i+24, i+28, i+32, i+36 ) : ( 
+        uint32be(j) ^ uint32be(j+4)
+      )
+    )
+}

--- a/malvidin/yara_multibyte_xor.py
+++ b/malvidin/yara_multibyte_xor.py
@@ -1,0 +1,114 @@
+from binascii import hexlify
+
+
+input_1 = r'Software\Microsoft\Windows\CurrentVersion\Run'
+input_2 = r'https://github.com/100DaysofYARA'
+
+
+blank16 = '''
+rule {title}_2byte
+{{
+  meta:
+    author = "malvidin"
+    description = "Look for two byte xor of target string. Creating ~64K separate rules is faster (~12MB rule file)"
+    warning = "Loops over entire file, very poor performance."
+    target_string = "{target_string}"
+  condition:
+    for any i in ( 0 .. filesize ) : (
+        uint16be(i) ^ uint16be(i+2) == {first_xor}
+        and not for 0x{acccum_plus_one:x} j in ( {offsets} ) : ( 
+            uint16be(j) ^ uint16be(j+2) )
+            and for 0x{accum:x} j in ( {offsets} ) : ( uint16be(j) ^ uint16be(j+2) )
+    )
+}}
+'''
+
+blank24 = '''
+rule {title}_3byte 
+{{
+  meta:
+    author = "malvidin"
+    description = "Look for three byte xor of target string. Creating ~16M separate rules would probably be faster (~3.2 GB rule file)"
+    warning = "Loops over entire file, very poor performance."
+    target_string = "{target_string}"
+  condition:
+    for any i in ( 0 .. filesize ) : ( 
+      ( ( uint32be(i) ^ uint32be(i+3) ) >> 8 ) == {first_xor}
+      and not for 0x{acccum_plus_one:x} j in ( {offsets} ) : ( 
+        ( uint32be(j) ^ uint32be(j+3) ) >> 8 
+      )
+      and for 0x{accum:x} j in ( {offsets} ) : ( 
+        ( uint32be(j) ^ uint32be(j+3) ) >> 8
+      )
+    )
+}}
+'''
+
+blank32 = '''
+rule {title}_4byte 
+{{
+  meta:
+    author = "malvidin"
+    description = "Look for four byte xor of target string. Creating ~4G separate rules would probably be faster (~860 GB rule file)"
+    warning = "Loops over entire file, very poor performance."
+    target_string = "{target_string}"
+  condition:
+    for any i in ( 0 .. filesize ) : ( 
+      uint32be(i) ^ uint32be(i+4) == {first_xor}
+      and not for 0x{acccum_plus_one:x} j in ( {offsets} ) : ( 
+        uint32be(j) ^ uint32be(j+4) 
+      )
+      and for 0x{accum:x} j in ( {offsets} ) : ( 
+        uint32be(j) ^ uint32be(j+4)
+      )
+    )
+}}
+'''
+
+d = {
+    2: blank16,
+    3: blank24,
+    4: blank32,
+}
+
+
+def generate_rules(input_string, title, out_file=None):
+    input_bytes = input_string.encode('utf-8')
+    if len(input_bytes) < 12:
+        print('input is not long enough')
+        return
+    if out_file is not None:
+        with open(out_file, 'w') as yf:
+            yf.write('')
+    for i in (2, 3, 4):
+        first = True
+        first_xor = b''
+        accum = 0
+        last_offset = 0
+        for j in range(0, len(input_bytes), i):
+            if len(input_bytes[j + i:j + 2 * i]) < i:
+                break
+            xor_val = b'0x' + hexlify(bytes(a ^ b for a, b in zip(input_bytes[j:j + i], input_bytes[j + i:j + 2 * i])))
+            if first:
+                first = False
+                first_xor = xor_val
+            accum += int(xor_val, 16)
+            last_offset = j
+        yr = d[i].format(
+            title=title,
+            target_string=input_string.replace('\\', '\\\\'),
+            first_xor=first_xor.decode('latin1'),
+            accum=accum,
+            acccum_plus_one=accum+1,
+            string_len=last_offset,
+            offsets=', '.join([f'i+{offset}' for offset in range(0, j, i)])
+        )
+        if out_file is None:
+            print(yr)
+        else:
+            with open(out_file, 'a') as yf:
+                yf.write(yr)
+
+
+generate_rules(input_1, "current_version", 'current_version.yara')
+generate_rules(input_2, "days_of_yara_url",  '100_days_of_yara.yara')

--- a/malvidin/yara_multibyte_xor.py
+++ b/malvidin/yara_multibyte_xor.py
@@ -17,8 +17,9 @@ rule {title}_2byte
     for any i in ( 0 .. filesize ) : (
         uint16be(i) ^ uint16be(i+2) == {first_xor}
         and not for 0x{acccum_plus_one:x} j in ( {offsets} ) : ( 
-            uint16be(j) ^ uint16be(j+2) )
-            and for 0x{accum:x} j in ( {offsets} ) : ( uint16be(j) ^ uint16be(j+2) )
+            uint16be(j) ^ uint16be(j+2) 
+        )
+        and for 0x{accum:x} j in ( {offsets} ) : ( uint16be(j) ^ uint16be(j+2) )
     )
 }}
 '''


### PR DESCRIPTION
These rules are slow, but will match a 2, 3, or 4-byte XOR of a target string in a rule file that is under 5K.