### PR TITLE
Add days 49 to 99

### DIFF
--- a/shellcromancer/exploit-cve-2022-46689.yar
+++ b/shellcromancer/exploit-cve-2022-46689.yar
@@ -1,0 +1,40 @@
+rule file_cve_2022_46689
+{
+  meta:
+    description = "Identify macOS binaries exploiting CVE-2022-46689 (MacDirtyCoW)."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.04.05"
+    reference = "https://github.com/zhuowei/MacDirtyCowDemo/"
+    sample = "2a3cf68a766440bee6cf58f4ad5d390adc8d01f746ac838dc132968d846faf49"
+    DaysofYARA = "95/100"
+
+  strings:
+    $api0 = "dispatch_semaphore_create"
+    $api1 = "pthread_mutex_init"
+    $api2 = "wrong mem_entry size"
+    $api3 = "vm_read_overwrite"
+    $api4 = "vm_deallocate"
+    $api5 = "pthread_create"
+    $api6 = "pthread_mutex_lock"
+    $api7 = "pthread_mutex_unlock"
+
+    $log0 = "Testing for %ld seconds..."
+    $log1 = "Ran %d times in %ld seconds with no failure"
+    $log2 = "RO mapping was modified"
+    $log3 = "no diff?"
+    $log4 = "too long!"
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and (
+    3 of ($log*) or
+    all of ($api*)
+    )
+}

--- a/shellcromancer/exploit-cve-2023-23397.yar
+++ b/shellcromancer/exploit-cve-2023-23397.yar
@@ -1,0 +1,19 @@
+rule exploit_cve_2023_23397
+{
+	meta:
+		description = "Detect exploitation of CVE-2023-23397."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.14"
+		reference = "https://github.com/microsoft/CSS-Exchange/blob/a4c096e8b6e6eddeba2f42910f165681ed64adf7/docs/Security/CVE-2023-23397.md"
+		reference = "https://www.mdsec.co.uk/2023/03/exploiting-cve-2023-23397-microsoft-outlook-elevation-of-privilege-vulnerability/"
+		DaysofYARA = "73/100"
+
+	strings:
+		$ = "PidLidReminderFileParameter" wide ascii
+
+	condition:
+		uint32be(0) == 0xD0CF11E0 and // OLE MSG file
+		uint32be(4) == 0xA1B11AE1 and
+		any of them
+}

--- a/shellcromancer/file_icns.yar
+++ b/shellcromancer/file_icns.yar
@@ -1,0 +1,20 @@
+import "console"
+
+rule file_icns
+{
+	meta:
+		description = "Identify Apple Icon files (.icns)"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.02.20"
+		reference = "https://en.wikipedia.org/wiki/Apple_Icon_Image_format"
+		DaysofYARA = "51/100"
+
+	strings:
+		$header = "icns" private
+		$ostype = { ( 69 63 | 49 43 ) ?? ?? }
+
+	condition:
+		$header at 0 and
+		$ostype at 8
+}

--- a/shellcromancer/file_ipsw.yar
+++ b/shellcromancer/file_ipsw.yar
@@ -1,0 +1,21 @@
+rule file_ipsw
+{
+  meta:
+    description = "Identify Apple iPhone Software (.ipsw) files"
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.29"
+    reference = "http://newosxbook.com/bonus/vol1AppA.html"
+    DaysofYARA = "88/100"
+
+  strings:
+    $s0 = "Restore.plist"
+    $s1 = "BuildManifest.plist"
+    $s2 = "kernelcache.release."
+    $s3 = "Firmware/dfu/"
+    $s4 = ".dmg"
+
+  condition:
+    uint32be(0) == 0x504B0304 and
+    all of them
+}

--- a/shellcromancer/file_sdef.yar
+++ b/shellcromancer/file_sdef.yar
@@ -1,0 +1,19 @@
+rule file_sdef
+{
+  meta:
+    description = "Identify Apple scripting dictionary files."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.04.02"
+    reference = "https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/AboutScriptingTerminology.html"
+    sample = "11935d4a6ebabc75a45e79d7d3830c47701474b0f34d92937fa32c6eb6a22fcd"
+    DaysofYARA = "92/100"
+
+  strings:
+    $dtd = "/System/Library/DTDs/sdef.dtd"
+    $s0  = "<?xml"
+    $s1  = "<dictionary"
+
+  condition:
+    all of them
+}

--- a/shellcromancer/info_macho_python.yar
+++ b/shellcromancer/info_macho_python.yar
@@ -1,0 +1,25 @@
+rule info_macho_python {
+  meta:
+    description = "Identify Mach-O executables with bundled python content."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.31"
+    references = "https://www.uptycs.com/blog/macstealer-command-and-control-c2-malware"
+    sample = "1153fca0b395b3f219a6ec7ecfc33f522e7b8fc6676ecb1e40d1827f43ad22be"
+    DaysofYARA = "90/100"
+
+  strings:
+    $s0 = "@_Py"
+    $s1 = "@executable_path/Python"
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    #s0 > 10 or $s1
+}

--- a/shellcromancer/info_macos_file_metadata.yar
+++ b/shellcromancer/info_macos_file_metadata.yar
@@ -1,0 +1,25 @@
+rule info_macos_file_metadata
+{
+  meta:
+    description = "Identify macho executable with references to file metadata."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.04.08"
+    DaysofYARA = "98/100"
+
+  strings:
+    $cmd0 = "mdls"
+    $cmd1 = { 6C 73 [0-6] 20 [0-6] 2D [0-8] 6C [0-8] 40 }
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    uint32(0xc) == 0x2 and  // mach_header->filetype == MH_EXECUTE
+    any of them
+}

--- a/shellcromancer/info_macos_scpt_applet.yar
+++ b/shellcromancer/info_macos_scpt_applet.yar
@@ -1,0 +1,24 @@
+rule info_macos_scpt_applet
+{
+  meta:
+    description = "Identify macOS AppleScript Applet stubs."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.04.06"
+    DaysofYARA = "96/100"
+
+  strings:
+    $s0 = "_OpenDefaultComponent"
+    $s1 = "_CallComponentDispatch"
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    all of them
+}

--- a/shellcromancer/info_macos_xattrs.yar
+++ b/shellcromancer/info_macos_xattrs.yar
@@ -1,0 +1,32 @@
+rule susp_macos_xattrs
+{
+	meta:
+		description = "Identify macOS executables that manipulate extended attributes (xattr's)"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.13"
+		DaysofYARA = "72/100"
+
+	strings:
+		$xattr_quarantine = "com.apple.quarantine"
+		$xattr_macl = "com.apple.macl"
+		$xattr_provenance = "com.apple.provenance"
+		$xattr_sip = "com.apple.rootless"
+
+		$allow_shipitsqrl = "SQRLShipIt"
+		$allow_kbfs = "kbfs/libfuse.(*QuarantineXattrHandler)"
+		$allow_goupdater = "go-updater/keybase.context.Apply"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		uint32(0xc) == 0x2 and // mach_header->filetype == MH_EXECUTE
+		any of ($xattr*) and
+		not any of ($allow*)
+}

--- a/shellcromancer/info_nop_sled.yar
+++ b/shellcromancer/info_nop_sled.yar
@@ -1,0 +1,26 @@
+rule info_nop_sled
+{
+	meta:
+		description = "Identify a large region of nop'd bytes."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.07"
+		DaysofYARA = "66/100"
+
+	strings:
+		// python -c 'print("{ " + "90 " * 100 + "}")'
+		$nop = { 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 }
+
+	condition:
+		(
+			int16(0) == 0x5a4d or      // PE
+			uint32(0) == 0x464c457f or // ELF
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		any of them
+}

--- a/shellcromancer/info_padded_dmg.yar
+++ b/shellcromancer/info_padded_dmg.yar
@@ -1,0 +1,17 @@
+rule info_padded_dmg
+{
+  meta:
+    description = "Identify Apple DMG with padding between the plist and trailer sections."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.04.01"
+    reference = "https://objective-see.org/blog/blog_0x70.html"
+    DaysofYARA = "91/100"
+
+  strings:
+    $plist = "</plist>\x0a"
+
+  condition:
+    uint32be(filesize - 512) == 0x6b6f6c79 and  // "koly" trailer of DMG
+    not $plist at filesize - 521  // trailer is not prefixed by property list
+}

--- a/shellcromancer/info_python_nuitka.yar
+++ b/shellcromancer/info_python_nuitka.yar
@@ -1,0 +1,25 @@
+rule info_python_nuitka
+{
+  meta:
+    description = "Identify Nuitka-compiled Python executable"
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.28"
+    reference = "https://nuitka.net"
+    DaysofYARA = "87/100"
+
+  strings:
+    $nuitka = "nuitka" nocase
+
+  condition:
+    (
+    int16(0) == 0x5a4d or  // PE
+    uint32(0) == 0x464c457f or  // ELF
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and #nuitka > 10
+}

--- a/shellcromancer/lang_python.yar
+++ b/shellcromancer/lang_python.yar
@@ -1,0 +1,13 @@
+rule lang_python_bytecode
+{
+  meta:
+    description = "Identify Python compiled bytecode"
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.27"
+    reference = "https://nedbatchelder.com/blog/200804/the_structure_of_pyc_files.html"
+    DaysofYARA = "86/100"
+
+  condition:
+    uint32be(0) == 0x420D0D0A
+}

--- a/shellcromancer/macho_no_pagezero.yar
+++ b/shellcromancer/macho_no_pagezero.yar
@@ -1,0 +1,31 @@
+/*
+https://github.com/kpwn/NULLGuard
+> but I haven't yet encountered a non-malicious binary lacking PAGEZERO.
+*/
+rule macho_no_pagezero_no_module
+{
+	meta:
+		description = "Identify macho executable without a __PAGEZERO segment without the module module."
+		author = "@shellcromancer"
+		version = "1.2"
+		date = "2023.03.02"
+		sample = "6ab836d19bc4b69dfe733beef295809e15ace232be0740bc326f58f9d31d8197" // FinSpy
+		DaysofYARA = "61/100"
+
+	strings:
+		$segment1 = "__PAGEZERO"
+		$segment2 = "__ZERO"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		uint32(0xc) == 0x2 and                   // mach_header->filetype == MH_EXECUTE
+		not $segment1 in (0 .. uint32(0x14)) and // 0 to mach_header->sizeofcmds
+		not $segment2 in (0 .. uint32(0x14))
+}

--- a/shellcromancer/macos_bundles.yar
+++ b/shellcromancer/macos_bundles.yar
@@ -96,3 +96,28 @@ rule macos_bundle_colorpicker
 			)
 		)
 }
+
+rule macos_bundle_findersync_appex
+{
+	meta:
+		description = "Identify macOS Finder Sync plugins - a macOS persistence vector."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.04.09"
+		reference = "https://theevilbit.github.io/beyond/beyond_0026/"
+		DaysofYARA = "99/100"
+
+	strings:
+		$interface = "FinderSync"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		any of them
+}

--- a/shellcromancer/macos_bundles.yar
+++ b/shellcromancer/macos_bundles.yar
@@ -72,3 +72,27 @@ rule macos_bundle_saver
 			)
 		)
 }
+
+rule macos_bundle_colorpicker
+{
+	meta:
+		description = "Identify macOS Color Picker's - a macOS persistence vector."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.02.18"
+		reference = "https://theevilbit.github.io/beyond/beyond_0017/"
+		DaysofYARA = "49/100"
+
+	strings:
+		$init1 = "NSColorPicker"
+		$init2 = "NSColorPickingCustom"
+
+	condition:
+		all of them and
+		(
+			macho.filetype == macho.MH_BUNDLE or
+			for any file in macho.file : (
+				file.filetype == macho.MH_BUNDLE
+			)
+		)
+}

--- a/shellcromancer/macos_cloudmensis.yar
+++ b/shellcromancer/macos_cloudmensis.yar
@@ -1,0 +1,42 @@
+// source: /Library/Apple/System/Library/CoreServices/XProtect.bundle/Contents/Resources/XProtect.yara
+rule XProtect_snowdrift
+{
+	meta:
+		description = "SNOWDRIFT"
+	strings:
+		$a = "https://api.pcloud.com/getfilelink?path=%@&forcedownload=1"
+		$b = "-[Management initCloud:access_token:]"
+		$c = "*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.hwp;*.hwpx;*.csv;*.pdf;*.rtf;*.amr;*.3gp;*.m4a;*.txt;*.mp3;*.jpg;*.eml;*.emlx"
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		2 of them
+}
+
+rule mal_macos_cloudmensis
+{
+	meta:
+		description = "Identify the CloudMensis/SNOWDRIFT malware"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.02.21"
+		reference = "https://www.welivesecurity.com/2022/07/19/i-see-what-you-did-there-look-cloudmensis-macos-spyware/"
+		sample = "317ce26cae14dc9a5e4d4667f00fee771b4543e91c944580bbb136e7fe339427"
+		DaysofYARA = "52/100"
+
+	strings:
+		$ = "SearchAndMoveFS:removable:"
+		$ = "SavePetConfigData"
+		$ = "csrutil status | grep disabled"
+		$ = "CheckScreenSaverState"
+
+	condition:
+		all of them
+
+}

--- a/shellcromancer/mal_ddosia.yar
+++ b/shellcromancer/mal_ddosia.yar
@@ -1,0 +1,19 @@
+
+rule mal_ddosia_go_stresser_client
+{
+	meta:
+		description = "Identify the ddosia/go_stresser client"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.02.27"
+		sample = "7e1727e018a040920c4b4d573d2f4543733ed8e3f185a9596f8ba2c70029a2bb"
+		DaysofYARA = "58/100"
+
+	strings:
+		$s1 = "client_id.txt"
+		$s2 = "_go_stresser"
+		$s3 = "\\$_\\d|\\$_\\d{2}"
+
+	condition:
+		all of them
+}

--- a/shellcromancer/mal_final_cut_pro.yar
+++ b/shellcromancer/mal_final_cut_pro.yar
@@ -12,7 +12,7 @@ rule mal_final_cut_pro
 	strings:
 		$s1 = "Task %@ is not running"
 		$s2 = "STPrivilegedTaskDidTerminateNotification"
-		$s3 = "I2P"
+		$s3 = "I2P" nocase
 		$s4 = "FileExists"
 		$s5 = "DirExists"
 		$s6 = "Traktor"
@@ -27,4 +27,34 @@ rule mal_final_cut_pro
 			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
 		) and
 		4 of them
+}
+
+
+
+rule mal_final_cut_pro_i2pd
+{
+	meta:
+		description = "Identify macOS Logic Pro X Cryptocurrency malware's embedded I2P daemon"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.02.26"
+		sample = "810bb73988dc47558b220047534d6dab9a55632c1defa40a761543ebaaa2f02c"
+		reference = "https://www.jamf.com/blog/cryptojacking-macos-malware-discovered-by-jamf-threat-labs/"
+		DaysofYARA = "57/100"
+
+	strings:
+		$s1 = "/Users/user/dev/i2pd/stage-x86_64/lib"
+		$s2 = "i2p::"
+		$s3 = "pidfile"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		all of them
 }

--- a/shellcromancer/mal_final_cut_pro.yar
+++ b/shellcromancer/mal_final_cut_pro.yar
@@ -1,0 +1,30 @@
+rule mal_final_cut_pro
+{
+	meta:
+		description = "Identify macOS Logic Pro X Cryptocurrency malware"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.02.25"
+		sample = "33114dd11009871fa6ad54797b45874d310eed2ad2f1da797f774701363be054"
+		reference = "https://www.jamf.com/blog/cryptojacking-macos-malware-discovered-by-jamf-threat-labs/"
+		DaysofYARA = "56/100"
+
+	strings:
+		$s1 = "Task %@ is not running"
+		$s2 = "STPrivilegedTaskDidTerminateNotification"
+		$s3 = "I2P"
+		$s4 = "FileExists"
+		$s5 = "DirExists"
+		$s6 = "Traktor"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		4 of them
+}

--- a/shellcromancer/mal_macos_coinminer.yar
+++ b/shellcromancer/mal_macos_coinminer.yar
@@ -1,0 +1,28 @@
+rule mal_macos_coinminer_xmrig
+{
+	meta:
+		description = "Identify macOS CoinMiner malware."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.05"
+		sample = "fabe0b41fb5bce6bda8812197ffd74571fc9e8a5a51767bcceef37458e809c5c"
+		DaysofYARA = "64/100"
+
+	strings:
+		$s0 = "XMRig"
+		$s1 = "cryptonight"
+		$s3 = "user\": \"pshp"
+		$s4 = "pass\": \"x"
+		$s5 = "url\": \"127.0.0.1:"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		all of them
+}

--- a/shellcromancer/mal_macos_crossrat.yar
+++ b/shellcromancer/mal_macos_crossrat.yar
@@ -1,0 +1,39 @@
+rule mal_macos_crossrat_jar
+{
+  meta:
+    description = "Identify macOS CrossRAT JAR bundle"
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.18"
+    reference = "https://objective-see.org/blog/blog_0x28.html"
+    sample = "15af5bbf3c8d5e5db41fd7c3d722e8b247b40f2da747d5c334f7fd80b715a649"
+    DaysofYARA = "77/100"
+
+  strings:
+    $client = "crossrat/client.class"
+
+  condition:
+    uint32be(0) == 0x0504B0304 and
+    all of them
+}
+
+rule mal_macos_crossrat_client
+{
+  meta:
+    description = "Identify macOS CrossRAT client class"
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.18"
+    reference = "https://objective-see.org/blog/blog_0x28.html"
+    sample = "d7e2bb4babf56a84febb822e7c304159367ba61c97afa30aa1e8d93686c1c6f0"
+    DaysofYARA = "77/100"
+
+  strings:
+    $jar   = "mediamgrs.jar"
+    $name0 = "os.name"
+    $name1 = "user.name"
+
+  condition:
+    uint32be(0) == 0xCAFEBABE and
+    all of them
+}

--- a/shellcromancer/mal_macos_dacls.yar
+++ b/shellcromancer/mal_macos_dacls.yar
@@ -1,0 +1,34 @@
+rule mal_macos_dacls
+{
+  meta:
+    description = "Identify the macOS DACLs backdoor."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.04.07"
+    sample = "846d8647d27a0d729df40b13a644f3bffdc95f6d0e600f2195c85628d59f1dc6"
+    DaysofYARA = "97/100"
+
+  strings:
+    $s0 = "SCAN\t%s\t%d.%d.%d.%d\t%d\n"
+    $s1 = "%Y-%m-%d %X"
+    $s2 = "{\"result\":\"ok\"}"
+
+    $f0 = "http_send_post"
+    $f1 = "fetch_response"
+    $f2 = "start_worm_scan"
+    $f3 = "MakePacketHeader"
+
+    $n0 = "mata_wc"
+    $n1 = "Mata"
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    (all of ($s*) or all of ($f*) or all of ($n*))
+}

--- a/shellcromancer/mal_macos_fkcodec.yar
+++ b/shellcromancer/mal_macos_fkcodec.yar
@@ -1,0 +1,29 @@
+rule mal_macos_fkcodec {
+  meta:
+    description = "Identify macOS FKCodec backdoor."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.25"
+    reference = "http://www.thesafemac.com/osxfkcodec-a-in-action/"
+    sample = "979c6de81cc0f4e0a770f720ab82e8c727a2d422fe6179684b239fe0dc28d86c"
+    DaysofYARA = "84/100"
+
+  strings:
+    $s0 = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:29.0) Gecko/20100101 Firefox/29.0"
+    $s1 = "/Users/yuriyfomenko/Develop/vova/projects/vidinstaller"
+    $s2 = "safari_name=([^&?]*)"
+    $s3 = "/tmp/download/ch.txt"
+    $s4 = "/wait"
+    $s5 = "/task"
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    3 of them
+}

--- a/shellcromancer/mal_macos_iwebupdate.yar
+++ b/shellcromancer/mal_macos_iwebupdate.yar
@@ -1,0 +1,56 @@
+rule mal_iwebservices
+{
+	meta:
+		description = "Identify the iWebServices malware"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.02.19"
+		reference = "https://objective-see.org/blog/blog_0x72.html"
+		sample = "3e66e664b05b695b0b018d3539412e6643d036c6d1000e03b399986252bddbfb"
+		DaysofYARA = "50/100"
+
+	strings:
+		$s1 = "/update.php"
+		$s2 = "/install.php"
+		$s3 = "/tmp/iwup.tmp"
+
+		$c1 = {
+			e8 [4]         // call    _strchr
+			49 89 c4       // mov     r12, rax
+			45 31 ed       // xor     r13d, r13d  {0x0}
+			4d 85 e4       // test    r12, r12
+			74 ??          // je      0x1000018ab
+			4c 89 e0       // mov     rax, r12
+			49 ff c4       // inc     r12
+			c6 00 00       // mov     byte [rax], 0x0
+			be 3b 00 00 00 // mov     esi, 0x3b
+			4c 89 e7       // mov     rdi, r12
+			e8 [4]         // call    _strchr
+			48 89 c3       // mov     rbx, rax
+			45 31 ed       // xor     r13d, r13d  {0x0}
+			48 85 db       // test    rbx, rbx
+			74 ??          // je      0x1000018ab
+			48 89 d8       // mov     rax, rbx
+			48 ff c3       // inc     rbx
+			c6 00 00       // mov     byte [rax], 0x0
+			be 3b 00 00 00 // mov     esi, 0x3b
+			48 89 df       // mov     rdi, rbx
+			e8 [4]         // call    _strchr
+			45 31 ed       // xor     r13d, r13d  {0x0}
+			48 85 c0       // test    rax, rax
+			74 ??          // je      0x10000188b
+		}
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		all of ($s*) or
+		all of ($c*)
+}
+

--- a/shellcromancer/mal_macos_loselose.yar
+++ b/shellcromancer/mal_macos_loselose.yar
@@ -1,0 +1,29 @@
+rule mal_macos_loselose : OSXLoseLoseA
+{
+	meta:
+		description = "Identify macOS LoseLose malware "
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.09"
+		reference = "http://loselose.net"
+		sample = "0e600ad7a40d1d935d85a47f1230a74e3ad4fd673177677827df9bca5bcb83e2"
+		DaysofYARA = "68/100"
+
+	strings:
+		$s1 = "/Users/zachgage/Projects/"
+		$s2 = "zach/virus/build/virus.build"
+		$s3 = "ofxDirList - attempting to open %s"
+		$s4 = "result in files on your hard drive"
+		$s5 = "lose/lose"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		4 of them
+}

--- a/shellcromancer/mal_macos_macstealer.yar
+++ b/shellcromancer/mal_macos_macstealer.yar
@@ -1,0 +1,40 @@
+rule mal_macos_macstealer {
+  meta:
+    description = "Identify macOS MacStealer malware."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.26"
+    references = "https://www.uptycs.com/blog/macstealer-command-and-control-c2-malware"
+    sample = "1153fca0b395b3f219a6ec7ecfc33f522e7b8fc6676ecb1e40d1827f43ad22be"
+    DaysofYARA = "85/100"
+
+  strings:
+    // config imports
+    $s0 = "data.keychain"
+    $s1 = "data.exdocusdecrypt"
+
+    // support_file_extensions
+    $s2 = { 74 78 74 [1-3] 75 2e 64 6f 63 [1-3] 75 2e 64 6f 63 78 [1-3] 75 2e 70 64 66 [1-3] 75 2e 78 6c 73 [1-3] 75 2e 78 6c 73 78 [1-3] 75 2e 70 70 74 [1-3] 75 2e 70 70 74 78 [1-3] 75 2e 6a 70 67 [1-3] 75 2e 70 6e 67 [1-3] 75 2e 62 6d 70 [1-3] 75 2e 6d 70 33 [1-3] 75 2e 7a 69 70 [1-3] 75 2e 72 61 72 [1-3] 75 2e 70 79 [1-3] 61 64 62 [1-3] 75 2e 63 73 76 [1-3] 75 2e 6a 70 65 67 }
+    // support_folder_names
+    $s3 = { 61 44 65 73 6b 74 6f 70 [1-3] 61 44 6f 63 75 6d 65 6e 74 73 [1-3] 61 44 6f 77 6e 6c 6f 61 64 73 [1-3] 61 4d 6f 76 69 65 73 [1-3] 61 4d 75 73 69 63 [1-3] 61 50 69 63 74 75 72 65 73 [1-3] 61 50 75 62 6c 69 63 }
+
+    // bot id
+    $s4 = "B8729059DDBF6359F136F699030BD4F5"
+
+    // OSAScript
+    $s5 = "osascript -e \\'display dialog \\\"{message}\\\" with title \\\"{title}\\\" with icon caution default answer \\\"\\\" with hidden answer"
+
+    // keychain 
+    $s6 = "security list-keychains"
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    3 of them
+}

--- a/shellcromancer/mal_macos_netwire.yar
+++ b/shellcromancer/mal_macos_netwire.yar
@@ -1,0 +1,62 @@
+
+rule mal_macos_netwire
+{
+	meta:
+		description = "Identify the macOS Netwire Client"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.10"
+		sample = "07a4e04ee8b4c8dc0f7507f56dc24db00537d4637afee43dbb9357d4d54f6ff4"
+		DaysofYARA = "69/100"
+
+	strings:
+		$s0 = "User-Agent: Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko"
+		$s1 = "%PATH%"
+		$s2 = "%HOME%"
+		$s3 = "%USER%"
+
+		$c0 = {
+			e8 [4]         //      call    sub_9487
+			83 c4 0c       //      add     esp, 0xc
+			bf ff 00 00 00 //      mov     edi, 0xff
+			ba f8 e? ?? ?? //      mov     edx, data_e2f8
+			89 d9          //      mov     ecx, ebx {var_6014}
+			57             //      push    edi {var_78b4}  {0xff}
+			68 ?? ?? ?? ?? //      push    data_e2f8 {var_78b8}
+			57             //      push    edi {var_78bc}  {0xff}
+			e8 [4]         //      call    sub_9502
+			83 c4 0c       //      add     esp, 0xc
+			ba f8 e? ?? ?? //      mov     edx, data_e3f8
+			89 d9          //      mov     ecx, ebx {var_6014}
+			57             //      push    edi {var_78b4}  {0xff}
+			68 ?? ?? ?? ?? //      push    data_e3f8 {var_78b8}
+			57             //      push    edi {var_78bc}  {0xff}
+			e8 [4]         //      call    sub_9502
+			83 c4 0c       //      add     esp, 0xc
+			bf 20 00 00 00 //      mov     edi, 0x20
+			ba f8 e? ?? ?? //      mov     edx, data_e4f8
+			89 d9          //      mov     ecx, ebx {var_6014}
+			57             //      push    edi {var_78b4}  {0x20}
+			68 ?? ?? ?? ?? //      push    data_e4f8 {var_78b8}
+			57             //      push    edi {var_78bc}  {0x20}
+			e8 [4]         //      call    sub_9502
+			83 c4 0c       //      add     esp, 0xc
+			ba 2a e? ?? ?? //      mov     edx, data_e52a
+			89 d9          //      mov     ecx, ebx {var_6014}
+			56             //      push    esi {var_78b4}  {0x10}
+			68 ?? ?? ?? ?? //      push    data_e52a {var_78b8}
+			56             //      push    esi {var_78bc}  {0x10}
+			e8 [3] ??      //      call    sub_9502
+		}
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		2 of them
+}

--- a/shellcromancer/mal_macos_pureland.yar
+++ b/shellcromancer/mal_macos_pureland.yar
@@ -1,0 +1,32 @@
+rule mal_macos_pureland
+{
+	meta:
+		description = "Identify macOS PureLand crypto stealer."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.04"
+		sample = "82633f6fec78560d657f6eda76d11a57c5747030847b3bc14766cec7d33d42be"
+		DaysofYARA = "63/100"
+
+	strings:
+		$s0 = "system_profiler SPHardwareDataType > /Users/"
+		$s1 = "security 2>&1 > /dev/null find-generic-password -ga 'Chrome' | awk '{print $2}' > /Users/"
+		$s2 = "/Library/Application Support/Exodus/exodus.wallet/" // Exodus Path
+		$s3 = "/.dkdbsqtl/vakkdsr"                                 // Electrum Path
+
+		$ext0 = "nkbihfbeogaeaoehlefnkodbefgpgknn" // MetaMask
+		$ext1 = "bfnaelmomeimhlpmgjnjophhpkkoljpa" // Phantom
+		$ext2 = "ibnejdfjmmkpcnlpebklmnkoeoihofec" // TronLink
+		$ext3 = "efbglgofoippbgcjepnhiblaibcnclgk" // Martian
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		all of them
+}

--- a/shellcromancer/mal_macos_pureland.yar
+++ b/shellcromancer/mal_macos_pureland.yar
@@ -1,4 +1,4 @@
-rule mal_macos_pureland
+rule mal_macos_pureland : stealer_0xfff
 {
 	meta:
 		description = "Identify macOS PureLand crypto stealer."
@@ -7,6 +7,7 @@ rule mal_macos_pureland
 		date = "2023.03.04"
 		sample = "82633f6fec78560d657f6eda76d11a57c5747030847b3bc14766cec7d33d42be"
 		DaysofYARA = "63/100"
+		DaysofYARA = "67/100"
 
 	strings:
 		$s0 = "system_profiler SPHardwareDataType > /Users/"
@@ -28,5 +29,5 @@ rule mal_macos_pureland
 			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
 			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
 		) and
-		all of them
+		60% of them
 }

--- a/shellcromancer/mal_macos_rshell.yar
+++ b/shellcromancer/mal_macos_rshell.yar
@@ -1,0 +1,25 @@
+rule mal_macos_rshell
+{
+	meta:
+		description = "Identify macOS rshell backdoor."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.19"
+		sample = "3a9e72b3810b320fa6826a1273732fee7a8e2b2e5c0fd95b8c36bbab970e830a"
+		DaysofYARA = "78/100"
+
+	strings:
+		$s0 = "/proc/self/exe"
+        $s1 = "/tmp/guid"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		all of them
+}

--- a/shellcromancer/mal_macos_silver_sparrow.yar
+++ b/shellcromancer/mal_macos_silver_sparrow.yar
@@ -18,3 +18,39 @@ rule mal_macos_silver_sparrow_distribution {
   condition:
     any of ($a*) and all of ($b*)
 }
+
+rule mal_macos_silver_sparrow {
+  meta:
+    description = "Identify macOS SilverSparrow distrubtion scripts."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.24"
+    references = "https://redcanary.com/blog/clipping-silver-sparrows-wings/"
+    sample = "b60f1c6b95b8de397e7d92072412d1970ba474ff168ccabbc641d2a65b307b8a"
+    DaysofYARA = "83/100"
+
+  strings:
+    $a0 = {
+    48 bf 48 65 6c 6c 6f 2c 20 57  // mov     rdi, 'Hello, W'
+    48 be 6f 72 6c 64 21 00 00 ed  // mov     rsi, 'orld!\x00\x00\xed'
+    e8                             // call    _$s7SwiftUI18LocalizedStringKeyV13stringLiteralACSS_tcfC
+    }
+    $a1 = {
+    48 bf 59 6f 75 20 64 69 64 20  // mov     rdi, 'You did '
+    48 be 69 74 21 00 00 00 00 eb  // mov     rsi, 'it!\x00\x00\x00\x00\xeb'
+    e8                             // call    _$s7SwiftUI18LocalizedStringKeyV13stringLiteralACSS_tcfC
+    }
+
+    $b0 = "SwiftUI6VStackVMn"
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    any of ($a*) and all of ($b*)
+}

--- a/shellcromancer/mal_macos_silver_sparrow.yar
+++ b/shellcromancer/mal_macos_silver_sparrow.yar
@@ -1,0 +1,20 @@
+rule mal_macos_silver_sparrow_distribution {
+  meta:
+    description = "Identify macOS SilverSparrow pkg distrubtion scripts."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.23"
+    references = "https://redcanary.com/blog/clipping-silver-sparrows-wings/"
+    sample = "b60f1c6b95b8de397e7d92072412d1970ba474ff168ccabbc641d2a65b307b8a"
+    DaysofYARA = "82/100"
+
+  strings:
+    $a0 = { 61 70 70 65 6E 64 4C 69 6E 65 (78 | 79) }
+    $a1 = { 77 72 69 74 65 54 6F 46 69 6C 65 (78 | 79) }
+
+    $b0 = "/usr/libexec/PlistBuddy -c 'Add :ProgramArguments:2 string \\\"~/Library/Application"
+    $b1 = "${initAgentPath};"
+
+  condition:
+    any of ($a*) and all of ($b*)
+}

--- a/shellcromancer/mal_macos_smoothoperator.yar
+++ b/shellcromancer/mal_macos_smoothoperator.yar
@@ -23,7 +23,7 @@ rule mal_macos_smoothoperator {
     uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
     uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
     ) and
-    any of them
+    2 of them
 }
 
 rule mal_macos_smoothoperator_updateagent {
@@ -33,7 +33,7 @@ rule mal_macos_smoothoperator_updateagent {
     version = "1.0"
     date = "2023.04.03"
     references = "https://objective-see.org/blog/blog_0x74.html"
-    sample = "9e9a5f8d86356796162cee881c843cde9eaedfb3"
+    sample = "6c121f2b2efa6592c2c22b29218157ec9e63f385e7a1d7425857d603ddef8c59"
     DaysofYARA = "93/100"
 
   strings:
@@ -41,6 +41,9 @@ rule mal_macos_smoothoperator_updateagent {
     $s1 = "3cx_auth_id=%s;3cx_auth_token_content=%s;__tutma=true" xor
     $s2 = "%s/Library/Application Support/3CX Desktop App/config.json" xor
     $s3 = "%s/Library/Application Support/3CX Desktop App/.main_storage" xor
+    $s4 = "gzip, deflate" xor(0x01-0xff)
+    $s5 = "User-Agent" xor(0x01-0xff)
+    $s6 = "Connection" xor(0x01-0xff)
 
     $f0 = "parse_json_config"
     $f1 = "enc_text"

--- a/shellcromancer/mal_macos_smoothoperator.yar
+++ b/shellcromancer/mal_macos_smoothoperator.yar
@@ -3,7 +3,7 @@ rule mal_macos_smoothoperator {
     description = "Identify macOS SmoothOperator first stage."
     author = "@shellcromancer"
     version = "1.0"
-    date = "2023.03.20"
+    date = "2023.03.30"
     references = "https://objective-see.org/blog/blog_0x73.html"
     sample = "a64fa9f1c76457ecc58402142a8728ce34ccba378c17318b3340083eeb7acc67"
     DaysofYARA = "89/100"
@@ -24,4 +24,36 @@ rule mal_macos_smoothoperator {
     uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
     ) and
     any of them
+}
+
+rule mal_macos_smoothoperator_updateagent {
+  meta:
+    description = "Identify macOS SmoothOperator second stage."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.04.03"
+    references = "https://objective-see.org/blog/blog_0x74.html"
+    sample = "9e9a5f8d86356796162cee881c843cde9eaedfb3"
+    DaysofYARA = "93/100"
+
+  strings:
+    $s0 = "https://sbmsa.wiki/blog/_insert"
+    $s1 = "3cx_auth_id=%s;3cx_auth_token_content=%s;__tutma=true" xor
+    $s2 = "%s/Library/Application Support/3CX Desktop App/config.json" xor
+    $s3 = "%s/Library/Application Support/3CX Desktop App/.main_storage" xor
+
+    $f0 = "parse_json_config"
+    $f1 = "enc_text"
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    2 of ($s*) or
+    all of ($f*)
 }

--- a/shellcromancer/mal_macos_smoothoperator.yar
+++ b/shellcromancer/mal_macos_smoothoperator.yar
@@ -1,0 +1,27 @@
+rule mal_macos_smoothoperator {
+  meta:
+    description = "Identify macOS SmoothOperator first stage."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.20"
+    references = "https://objective-see.org/blog/blog_0x73.html"
+    sample = "a64fa9f1c76457ecc58402142a8728ce34ccba378c17318b3340083eeb7acc67"
+    DaysofYARA = "89/100"
+
+  strings:
+    $s0 = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.128 Safari/53" xor(0x01-0xff)
+    $s1 = "3cx_auth_id=%s;3cx_auth_token_content=%s;__tutma" xor(0x01-0xff)
+    $s2 = "%s/Library/Application Support/3CX Desktop App/%" xor(0x01-0xff)
+    $s3 = "/System/Library/CoreServices/SystemVersion.plist" xor(0x01-0xff)
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    any of them
+}

--- a/shellcromancer/mal_macos_systemd.yar
+++ b/shellcromancer/mal_macos_systemd.yar
@@ -1,0 +1,29 @@
+
+rule mal_macos_systemd
+{
+	meta:
+		description = "Identify the macOS systemd (Demsty, ReverseWindow) backdoor."
+		author = "@shellcromancer"
+		version = "0.1"
+		date = "2023.02.28"
+		reference = "https://malpedia.caad.fkie.fraunhofer.de/details/osx.systemd"
+		sample = "6b379289033c4a17a0233e874003a843cd3c812403378af68ad4c16fe0d9b9c4"
+		DaysofYARA = "59/100"
+
+	strings:
+		$s1 = "This file is corrupted and connot be opened\n"
+		$s2 = "#!/bin/sh\n. /etc/rc.common\nStartService (){\n    ConsoleMessage \"Start system Service\"\n"
+		$s3 = "}\nStopService (){\n    return 0\n}\nRestartService (){\n    return 0\n}\nRunService \"$1\"\n"
+		$s4 = "StartupParameters.plist"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		all of them
+}

--- a/shellcromancer/mal_macos_ventir.yar
+++ b/shellcromancer/mal_macos_ventir.yar
@@ -1,0 +1,26 @@
+rule mal_macos_ventir
+{
+  meta:
+    description = "Identify macOS Ventir backdoor."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.19"
+    references = "https://securelist.com/the-ventir-trojan-assemble-your-macos-spy/67267/"
+    sample = "59539ff9af82c0e4e73809a954cf2776636774e6c42c281f3b0e5f1656e93679"
+    DaysofYARA = "79/100"
+
+  strings:
+    $s0 = "/proc/self/exe"
+    $s1 = "/bin/mv -f %s/updated.kext /System/Library/Extensions/updated.kext"
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    all of them
+}

--- a/shellcromancer/mal_macos_ventir.yar
+++ b/shellcromancer/mal_macos_ventir.yar
@@ -1,10 +1,9 @@
-rule mal_macos_ventir
-{
+rule mal_macos_ventir_dropper: dropper {
   meta:
-    description = "Identify macOS Ventir backdoor."
+    description = "Identify macOS Ventir backdoor dropper."
     author = "@shellcromancer"
     version = "1.0"
-    date = "2023.03.19"
+    date = "2023.03.20"
     references = "https://securelist.com/the-ventir-trojan-assemble-your-macos-spy/67267/"
     sample = "59539ff9af82c0e4e73809a954cf2776636774e6c42c281f3b0e5f1656e93679"
     DaysofYARA = "79/100"
@@ -23,4 +22,36 @@ rule mal_macos_ventir
     uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
     ) and
     all of them
+}
+
+rule mal_macos_ventir_keylog: keylogger {
+  meta:
+    description = "Identify macOS Ventir backdoor's keylogger component."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.21"
+    references = "https://securelist.com/the-ventir-trojan-assemble-your-macos-spy/67267/"
+    sample = "92667ebbd1bc05e1abd6078d7496c26e50353122bc71b89135f2c71bcad18440"
+    DaysofYARA = "80/100"
+
+  strings:
+    $s0     = "[command]"
+    $s1     = "[option]"
+    $s2     = "/Library/.local/.logfile"
+
+    $keytab = { 61 73 64 66 68 67 7a 78 63 76 00 62 71 77 65 72 79 74 31 32 33 34 36 35 3d 39 37 2d 38 30 5d 6f 75 5b 69 70 0d 6c 6a 27 6b 3b 5c 2c 2f 6e 6d 2e 09 20 60 08 00 1b 00 00 00 00 00 00 00 00 00 00 00 2e 00 2a 00 2b 00 00 00 00 00 2f 0d 00 2d 00 00 00 30 31 32 33 34 35 36 37 38 39 }
+
+    $fp     = "/proc/self/exe"
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    all of ($s*) and $keytab and
+    not $fp
 }

--- a/shellcromancer/mal_macos_ventir.yar
+++ b/shellcromancer/mal_macos_ventir.yar
@@ -55,3 +55,33 @@ rule mal_macos_ventir_keylog: keylogger {
     all of ($s*) and $keytab and
     not $fp
 }
+
+rule mal_macos_ventir_watchdog {
+  meta:
+    description = "Identify macOS Ventir backdoor's watchdog component - reweb."
+    author = "@shellcromancer"
+    version = "1.0"
+    date = "2023.03.21"
+    references = "https://securelist.com/the-ventir-trojan-assemble-your-macos-spy/67267/"
+    sample = "14e763ed4e95bf13a5b5c4ce98edbe2bbbec0d776d66726dfe2dd8b1f3079cb1"
+    DaysofYARA = "81/100"
+
+  strings:
+    $s0 = "/Users/maakira/"
+    $s1 = "killall -9 update"
+    $s2 = "reweb"
+
+    $fp = "/proc/self/exe"
+
+  condition:
+    (
+    uint32(0) == 0xfeedface or  // Mach-O MH_MAGIC
+    uint32(0) == 0xcefaedfe or  // Mach-O MH_CIGAM
+    uint32(0) == 0xfeedfacf or  // Mach-O MH_MAGIC_64
+    uint32(0) == 0xcffaedfe or  // Mach-O MH_CIGAM_64
+    uint32(0) == 0xcafebabe or  // Mach-O FAT_MAGIC
+    uint32(0) == 0xbebafeca  // Mach-O FAT_CIGAM
+    ) and
+    all of ($s*) and
+    not $fp
+}

--- a/shellcromancer/mal_macos_weaponx.yar
+++ b/shellcromancer/mal_macos_weaponx.yar
@@ -1,0 +1,30 @@
+
+
+rule mal_macos_weaponx
+{
+	meta:
+		description = "Identify the macOS WeaponX rootkit PoC."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.11"
+		reference = "http://phrack.org/issues/66/16.html"
+		sample = "5cf59f415ee67784227a2e9009ba9b3b3866d28d3d8f2b2c174368e1afc6ef96"
+		DaysofYARA = "70/100"
+
+	strings:
+		$s0 = "r00t"
+		$s1 = "com.nemo.kext.WeaponX"
+		$s2 = "_antimain"
+		$s3 = "_realmain"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		3 of them
+}

--- a/shellcromancer/mal_macos_xslcmd.yar
+++ b/shellcromancer/mal_macos_xslcmd.yar
@@ -1,0 +1,28 @@
+rule mal_macos_xslcmd
+{
+	meta:
+		description = "Identify macOS XslCmd malware."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.03"
+		reference = "https://malpedia.caad.fkie.fraunhofer.de/details/osx.xslcmd"
+		sample = "1db30d5b2bb24bcc4b68d647c6a2e96d984a13a28cc5f17596b3bfe316cca342"
+		DaysofYARA = "62/100"
+
+	strings:
+		$s0 = "/.fontset/"
+		$s1 = "pxupdate.ini"
+		$s2 = "dump address: 0x%p, len 0x%x"
+		$s3 = { 2f 74 6d 70 2f 6f 73 [3-4] 2e 6c 6f 67 }
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		all of them
+}

--- a/shellcromancer/program_thing.yar
+++ b/shellcromancer/program_thing.yar
@@ -1,0 +1,15 @@
+rule program
+{
+	meta:
+		description = "Identify programs string thing"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.16"
+		DaysofYARA = "75/100"
+
+	strings:
+		$str = { 40 28 23 29 50 52 4F 47 52 41 4D 3A [0-20] 20 20 50 52 4F 4A 45 43 54 3A [0-20] 0A }
+
+	condition:
+		any of them
+}

--- a/shellcromancer/susp_encoded_ip.yar
+++ b/shellcromancer/susp_encoded_ip.yar
@@ -1,0 +1,16 @@
+rule susp_encoded_ip
+{
+	meta:
+		description = "Identify encoded IP addresses - a form of obfuscation"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.02.24"
+		DaysofYARA = "55/100"
+
+	strings:
+		$hex = /https?:\/\/0x[0-9A-Fa-f]+/
+		$oct = /https?:\/\/0\d{3}\.0\d{3}\.0\d{3}/
+
+	condition:
+		any of them
+}

--- a/shellcromancer/susp_macho_loader2.yar
+++ b/shellcromancer/susp_macho_loader2.yar
@@ -1,0 +1,28 @@
+rule susp_macho_loader
+{
+	meta:
+		description = "Identify Mach-O excutables like the ObjCShellcodeLoader"
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.17"
+		reference = "https://github.com/slyd0g/ObjCShellcodeLoader/tree/main"
+		sample = "0ca96a9647a3506aeda50c9f6df3d173098b80c81937777af245da768867a4c9"
+		DaysofYARA = "76/100"
+
+	strings:
+		$s1 = "mach_vm_write failed to write shellcode"
+		$s2 = "_mach_vm_allocate"
+		$s3 = "_mach_vm_protect"
+		$s4 = "_mach_vm_write"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		3 of them
+}

--- a/shellcromancer/susp_macos_elitelogger.yar
+++ b/shellcromancer/susp_macos_elitelogger.yar
@@ -1,0 +1,26 @@
+rule susp_macos_elite_keylogger
+{
+	meta:
+		description = "Identify macOS Elite Keylogger."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.06"
+		sample = "edf5033a273bfbaebc721eb8dc30370bc0cd2b596d40051e19fdd32475d62194"
+		DaysofYARA = "65/100"
+
+	strings:
+		$s0 = "Install_Elite_Keylogger"
+		$s1 = { 45 6C 69 74 65 [0-1] 4B 65 79 6C 6F 67 67 65 72 }
+		$s2 = "congratInvisible"
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		all of them
+}

--- a/shellcromancer/susp_macos_shellcode.yar
+++ b/shellcromancer/susp_macos_shellcode.yar
@@ -1,0 +1,80 @@
+rule susp_macos_shellcode
+{
+	meta:
+		description = "Identify macOS shellcode from @evilbit."
+		author = "@shellcromancer"
+		version = "1.0"
+		date = "2023.03.15"
+		reference = "https://github.com/theevilbit/shellcode/tree/master/osx/x64"
+		DaysofYARA = "74/100"
+
+	strings:
+		$binsh = {
+			48 31 f6                      // xor     rsi, rsi  {0x0}
+			56                            // push    rsi {var_8}  {0x0}
+			48 bf 2f 2f 62 69 6e 2f 73 68 // mov     rdi, 0x68732f6e69622f2f
+			57                            // push    rdi {var_10}  {0x68732f6e69622f2f}
+			48 89 e7                      // mov     rdi, rsp {var_10}
+			48 31 d2                      // xor     rdx, rdx  {0x0}
+			48 31 c0                      // xor     rax, rax  {0x0}
+			b0 02                         // mov     al, 0x2
+			48 c1 c8 28                   // ror     rax, 0x28  {0x2000000}
+			b0 3b                         // mov     al, 0x3b
+			0f 05                         // syscall
+		}
+
+		$bindsc = {
+			48 31 ff                      //  xor     rdi, rdi  {sub_0}
+			40 b7 02                      //  mov     dil, 0x2
+			48 31 f6                      //  xor     rsi, rsi  {sub_0}
+			40 b6 01                      //  mov     sil, 0x1
+			48 31 d2                      //  xor     rdx, rdx  {sub_0}
+			48 31 c0                      //  xor     rax, rax  {sub_0}
+			b0 02                         //  mov     al, 0x2
+			48 c1 c8 28                   //  ror     rax, 0x28  {0x2000000}
+			b0 61                         //  mov     al, 0x61
+			49 89 c4                      //  mov     r12, rax  {0x2000061}
+			0f 05                         //  syscall
+			49 89 c1                      //  mov     r9, rax
+			48 89 c7                      //  mov     rdi, rax
+			48 31 f6                      //  xor     rsi, rsi  {sub_0}
+			56                            //  push    rsi {var_8}  {sub_0}
+			be 01 02 11 5c                //  mov     esi, 0x5c110201
+			83 ee 01                      //  sub     esi, 0x1  {0x5c110200}
+			56                            //  push    rsi {var_10}  {0x5c110200}
+			48 89 e6                      //  mov     rsi, rsp {var_10}
+			b2 10                         //  mov     dl, 0x10
+			41 80 c4 07                   //  add     r12b, 0x7
+			4c 89 e0                      //  mov     rax, r12  {0x2000068}
+			0f 05                         //  syscall
+			48 31 f6                      //  xor     rsi, rsi
+			48 ff c6                      //  inc     rsi  {0x1}
+			41 80 c4 02                   //  add     r12b, 0x2
+			4c 89 e0                      //  mov     rax, r12  {0x200006a}
+			0f 05                         //  syscall
+			48 31 f6                      //  xor     rsi, rsi  {sub_0}
+			41 80 ec 4c                   //  sub     r12b, 0x4c
+			4c 89 e0                      //  mov     rax, r12  {0x200001e}
+			0f 05                         //  syscall
+			48 89 c7                      //  mov     rdi, rax
+			48 31 f6                      //  xor     rsi, rsi  {sub_0}
+			41 80 c4 3c                   //  add     r12b, 0x3c
+			4c 89 e0                      //  mov     rax, r12  {0x200005a}
+			0f 05                         //  syscall
+			48 ff c6                      //  inc     rsi
+			4c 89 e0                      //  mov     rax, r12  {0x200005a}
+			0f 05                         //  syscall
+			48 31 f6                      //  xor     rsi, rsi  {sub_0}
+			56                            //  push    rsi {var_18}  {sub_0}
+			48 bf 2f 2f 62 69 6e 2f 73 68 //  mov     rdi, 0x68732f6e69622f2f
+			57                            //  push    rdi {var_20}  {0x68732f6e69622f2f}
+			48 89 e7                      //  mov     rdi, rsp {var_20}
+			48 31 d2                      //  xor     rdx, rdx  {sub_0}
+			41 80 ec 1f                   //  sub     r12b, 0x1f  {0x3b}
+			4c 89 e0                      //  mov     rax, r12  {0x200003b}
+			0f 05                         //  syscall
+		}
+
+	condition:
+		any of them
+}

--- a/shellcromancer/susp_macos_sniperspy.yar
+++ b/shellcromancer/susp_macos_sniperspy.yar
@@ -1,0 +1,30 @@
+
+
+rule susp_macos_sniperspy
+{
+	meta:
+		description = "Identify the macOS SniperSpy backdoor."
+		author = "@shellcromancer"
+		version = "0.1"
+		date = "2023.02.12"
+		reference = "https://www.flexispy.com/en/compatibility.htm?utm_source=sniperspy"
+		sample = "529a659259e1a816d9192aab7b97d0281776ab8ef360d2c6c95e14a03ccda06a"
+		DaysofYARA = "71/100"
+
+	strings:
+		$s1 = "/Shared/.syslogagent/syslogset.plist"
+		$s2 = "syslogagent.app"
+		$s3 = "sniperspy"
+
+
+	condition:
+		(
+			uint32(0) == 0xfeedface or // Mach-O MH_MAGIC
+			uint32(0) == 0xcefaedfe or // Mach-O MH_CIGAM
+			uint32(0) == 0xfeedfacf or // Mach-O MH_MAGIC_64
+			uint32(0) == 0xcffaedfe or // Mach-O MH_CIGAM_64
+			uint32(0) == 0xcafebabe or // Mach-O FAT_MAGIC
+			uint32(0) == 0xbebafeca    // Mach-O FAT_CIGAM
+		) and
+		all of them
+}


### PR DESCRIPTION
List of changes since last PR:
```bash
$ git log --author 'shellcromancer' --since="2023-02-18T00:00:00-07:00" --pretty=format:"%ad%x09%s" --date=short --reverse
2023-02-18	add macos_bundle_colorpicker
2023-02-19	add mal_iwebservices
2023-02-20	add file_icns
2023-02-21	add macos_cloudmensis
2023-02-24	add susp_encoded_ip
2023-02-25	add mal_final_cut_pro
2023-02-26	add i2pd
2023-02-27	add mal_ddosia.yar
2023-02-28	add mal_macos_systemd
2023-03-02	add macho_no_pagezero
2023-03-03	add mal_macos_xslcmd
2023-03-04	add mal_macos_pureland
2023-03-05	add mal_macos_coinminer
2023-03-06	add susp_macos_elitelogger
2023-03-07	add info_nop_sled.yar
2023-03-08	fix: loosen pureland condition
2023-03-09	add mal_macos_loselose
2023-03-10	add mal_macos_netwire
2023-03-11	add mal_macos_weaponx
2023-03-12	add susp_macos_sniperspy.yar
2023-03-13	add info_macos_xattrs
2023-03-14	exploit-cve-2023-23397
2023-03-15	add susp_macos_shellcode
2023-03-16	add program_thing.yar
2023-03-17	add susp_macho_loader
2023-03-18	add crossrat
2023-03-19	add mal_macos_rshell.yar
2023-03-20	add mal_macos_ventir
2023-03-21	add mal_macos_ventir_keylog
2023-03-22	add mal_macos_ventir_watchdog
2023-03-23	add mal_macos_silver_sparrow.yar
2023-03-24	add mal_macos_silver_sparrow
2023-03-25	add mal_macos_fkcodec.yar
2023-03-26	add mal_macos_macstealer
2023-03-27	add lang_python_bytecode
2023-03-28	add info_python_nuitka
2023-03-29	add file_ipsw
2023-03-30	add mal_macos_smoothoperator
2023-03-31	add info_macho_python
2023-04-01	add info_padded_dmg.yar
2023-04-02	add file_sdef.yar
2023-04-03	add mal_macos_smoothoperator_updateagent
2023-04-04	fix: mal_macos_smoothoperator
2023-04-05	add exploit-cve-2022-46689
2023-04-06	add info_macos_scpt_applet
2023-04-07	add mal_macos_dacls
2023-04-08	add info_macos_file_metadata
2023-04-09	add macos_bundle_findersync_appex
```